### PR TITLE
Add scheduled build tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,15 @@
-name: Compile Lawndon Lite
+name: Build Tests
 
 on:
-  workflow_dispatch:
-  release:
-    types: [released]
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 3"
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,6 +20,12 @@ jobs:
       - name: Install libraries
         run: |
           arduino-cli lib install IBusBM Servo
+
+      - name: Lint project
+        uses: arduino/arduino-lint-action@v1
+        with:
+          path: ./lawndon
+          library-manager: update
 
       - name: Compile Lawndon
         uses: arduino/compile-sketches@v1
@@ -35,19 +40,3 @@ jobs:
           verbose: false
           cli-compile-flags: |
             - --export-binaries
-
-      - name: Package build
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          for dir in ./lawndon/build/*; do
-            if [ -d "${dir}" ]; then
-              tar -czvf "${dir}.tar.gz" -C "${dir}" .
-            fi
-          done
-
-      - name: Release build
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            lawndon/build/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Tests](https://github.com/jordojordo/lawndon-lite/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/jordojordo/lawndon-lite/actions/workflows/tests.yml)
+
 # Lawndon Lite
 
 > Note: Lawndon is a WIP and the construction can be modified entirely to fit your desired needs. 


### PR DESCRIPTION
This adds a few tests to be ran on pull requests to `main` and on a schedule of every Wednesday at 6am. It will first run the arduino linter against the library and will then compile Lawndon for the `arduino:avr:mega` fqbn.