### PR TITLE
Adjust timer freq for mower motor

### DIFF
--- a/lawndon/drive.h
+++ b/lawndon/drive.h
@@ -10,11 +10,11 @@ extern Servo leftEsc;
 extern Servo rightEsc;
 
 // pin defs
-#define ESC_LEFT_PWM            4
 #define ESC_LEFT_POWER          3
+#define ESC_LEFT_PWM            4
 
-#define ESC_RIGHT_PWM           11
 #define ESC_RIGHT_POWER         10
+#define ESC_RIGHT_PWM           11
 
 // Throttle positions
 #define ESC_MIN_THROTTLE        1000

--- a/lawndon/motor.cpp
+++ b/lawndon/motor.cpp
@@ -12,6 +12,9 @@ Motor::Motor() {}
 void Motor::setup() {
   Console.println(F("Initializing motor config"));
 
+  // Setup for changing the PWM frequency of pin 7
+  setupTimer4();
+
   // Attach Mower ESC
   Console.println(F("Attaching mower ESC"));
   mowerEsc.attach(ESC_MOWER_PWM, 1000, 2000);
@@ -34,4 +37,8 @@ void Motor::loop() {
   } else {
     mowerEsc.writeMicroseconds(1000);
   }
+}
+
+void Motor::setupTimer4() {
+    TCCR4B = TCCR4B & 0b11111000 | 0x04; // Set prescaler to 256 for Timer 4
 }

--- a/lawndon/motor.h
+++ b/lawndon/motor.h
@@ -14,6 +14,8 @@ public:
 
   virtual void setup();
   virtual void loop();
+
+  virtual void setupTimer4();
 };
 
 extern Motor motor;


### PR DESCRIPTION
In order to use the Flipsky FT85BS ESC with PPM, the frequency needs to be below 400hz:

> The PPM signal pulse width usually ranges from 1ms to 2ms, so theoretically the PPM control
frequency supports up to 500Hz. Considering the MCU clock accuracy, it is recommended to use
the PPM control frequency less than 400Hz.

This will adjust the timer used with pin 7 to a frequency of 256.