### PR TITLE
Add 4 wheel drive

### DIFF
--- a/.github/workflows/compile-lawndon.yml
+++ b/.github/workflows/compile-lawndon.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Arduino cli
-        uses: arduino/setup-arduino-cli@v1
+        uses: arduino/setup-arduino-cli@v2
 
       - name: Install libraries
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,14 +15,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Arduino cli
-        uses: arduino/setup-arduino-cli@v1
+        uses: arduino/setup-arduino-cli@v2
 
       - name: Install libraries
         run: |
           arduino-cli lib install IBusBM Servo
 
       - name: Lint project
-        uses: arduino/arduino-lint-action@v1
+        uses: arduino/arduino-lint-action@v2
         with:
           path: ./lawndon
           library-manager: update

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # Lawndon Lite
 
-> Note: Lawndon is a WIP and the construction can be modified entirely to fit your desired needs. 
+> Note: Lawndon is a WIP and the construction can be modified entirely to fit your desired needs.
+
+> *October 2024 Update*: I have rebuilt lawndon with a new chassis, a separate ESC for the mower motor and 4x4 capabilities, wiki will be updated soon...
 
 Before turning Lawndon into an autonomous mower, the first step is to create a remote controlled mower which can tackle any terrain. This can be accomplished by recycling any "outdated" electric mower you can find, I found a suitable [24v Worx mower](https://www.worx.com/24v-cordless-lawn-mower-wg782.html) which someone was throwing out. Eventually, I would like to construct a complete build for Lawndon that is reproducable by anyone with a 3d printer.
 

--- a/lawndon/drive.cpp
+++ b/lawndon/drive.cpp
@@ -3,8 +3,10 @@
 #include <Arduino.h>
 #include <Servo.h>
 
-Servo leftEsc;
-Servo rightEsc;
+Servo frontLeftEsc;
+Servo frontRightEsc;
+Servo rearLeftEsc;
+Servo rearRightEsc;
 Drive drive;
 
 Drive::Drive() {};
@@ -16,30 +18,37 @@ void Drive::setup() {
   
   // Attach ESCs
   Console.println(F("Attaching ESCs"));
-  leftEsc.attach(ESC_LEFT_PWM, 1000, 2000);
-  rightEsc.attach(ESC_RIGHT_PWM, 1000, 2000);
+  frontLeftEsc.attach(ESC_FRONT_LEFT_PWM, 1000, 2000);
+  frontRightEsc.attach(ESC_FRONT_RIGHT_PWM, 1000, 2000);
+  rearLeftEsc.attach(ESC_REAR_LEFT_PWM, 1000, 2000);
+  rearRightEsc.attach(ESC_REAR_RIGHT_PWM, 1000, 2000);
   delay(1);
 
   // Calibrate ESCs ( Needed for initial setup )
   // Console.println(F("Calibrating left ESC"));
-  // calibrateEsc(leftEsc);
+  // calibrateEsc(frontLeftEsc);
   // Console.println(F("Calibrating right ESC"));
-  // calibrateEsc(rightEsc);
+  // calibrateEsc(frontRightEsc);
 
   // Arm ESCs
-  Console.println(F("Arming left ESC"));
-  armEsc(leftEsc);
+  Console.println(F("Arming front ESCs"));
+  armEsc(frontLeftEsc);
+  armEsc(frontRightEsc);
 
-  Console.println(F("Arming right ESC"));
-  armEsc(rightEsc);
+  Console.println(F("Arming rear ESCs"));
+  armEsc(rearLeftEsc);
+  armEsc(rearRightEsc);
   delay(1);
 
-
   // Set ESC pins
-  pinMode(ESC_LEFT_PWM, OUTPUT);
-  pinMode(ESC_LEFT_POWER, OUTPUT);
-  pinMode(ESC_RIGHT_PWM, OUTPUT);
-  pinMode(ESC_RIGHT_POWER, OUTPUT);
+  pinMode(ESC_FRONT_LEFT_PWM, OUTPUT);
+  pinMode(ESC_FRONT_LEFT_POWER, OUTPUT);
+  pinMode(ESC_FRONT_RIGHT_PWM, OUTPUT);
+  pinMode(ESC_FRONT_RIGHT_POWER, OUTPUT);
+  pinMode(ESC_REAR_LEFT_PWM, OUTPUT);
+  pinMode(ESC_REAR_LEFT_POWER, OUTPUT);
+  pinMode(ESC_REAR_RIGHT_PWM, OUTPUT);
+  pinMode(ESC_REAR_RIGHT_POWER, OUTPUT);
   
   Console.println(F("Drive setup complete"));
 }
@@ -64,8 +73,10 @@ void Drive::loop() {
   driveRightSpeed = constrain(driveRightSpeed, ESC_MIN_THROTTLE, ESC_MAX_THROTTLE);
 
   // Drive motors
-  controlDriveMotor(driveLeftSpeed, leftEsc);
-  controlDriveMotor(driveRightSpeed, rightEsc);
+  controlDriveMotor(driveLeftSpeed, frontLeftEsc);
+  controlDriveMotor(driveRightSpeed, frontRightEsc);
+  controlDriveMotor(driveLeftSpeed, rearLeftEsc);
+  controlDriveMotor(driveRightSpeed, rearRightEsc);
 
   // Used for debugging control
   // Serial.print("Left speed = ");

--- a/lawndon/drive.h
+++ b/lawndon/drive.h
@@ -6,15 +6,21 @@
 #include <Servo.h>
 
 // ESC
-extern Servo leftEsc;
-extern Servo rightEsc;
+extern Servo frontLeftEsc;
+extern Servo frontRightEsc;
+extern Servo rearLeftEsc;
+extern Servo rearRightEsc;
 
 // pin defs
-#define ESC_LEFT_POWER          3
-#define ESC_LEFT_PWM            4
+#define ESC_FRONT_LEFT_POWER    3
+#define ESC_FRONT_LEFT_PWM      4
+#define ESC_FRONT_RIGHT_POWER   8
+#define ESC_FRONT_RIGHT_PWM     9
 
-#define ESC_RIGHT_POWER         10
-#define ESC_RIGHT_PWM           11
+#define ESC_REAR_LEFT_POWER     5
+#define ESC_REAR_LEFT_PWM       6
+#define ESC_REAR_RIGHT_POWER    10
+#define ESC_REAR_RIGHT_PWM      11
 
 // Throttle positions
 #define ESC_MIN_THROTTLE        1000


### PR DESCRIPTION
This will add 2 extra esc controls for rear wheels to enable 4 wheel drive.

The pin definitions have changed:
```c
#define ESC_FRONT_LEFT_POWER    3
#define ESC_FRONT_LEFT_PWM      4
#define ESC_FRONT_RIGHT_POWER   8
#define ESC_FRONT_RIGHT_PWM     9

#define ESC_REAR_LEFT_POWER     5
#define ESC_REAR_LEFT_PWM       6
#define ESC_REAR_RIGHT_POWER    10
#define ESC_REAR_RIGHT_PWM      11
```