### PR TITLE
Move dependencies - update test badge

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,12 +79,30 @@ jobs:
         run: |
           pnpm build:server
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --allow-insecure-entitlement security.insecure
+          install: true
+
       - name: Test Docker build for Server
-        working-directory: ${{ env.WORKING_DIR }}
-        run: |
-          docker build --no-cache --file ./Dockerfile.server --tag lawndon-pi-server-test .
+        uses: docker/build-push-action@v4
+        with:
+          context: ./pi
+          file: ./pi/Dockerfile.server
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lawndon-pi-server:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/lawndon-pi-server:${{ github.sha }}
 
       - name: Test Docker build for UI
-        working-directory: ${{ env.WORKING_DIR }}
-        run: |
-          docker build --no-cache --file ./Dockerfile.ui --tag lawndon-pi-ui-test .
+        uses: docker/build-push-action@v4
+        with:
+          context: ./pi
+          file: ./pi/Dockerfile.ui
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lawndon-pi-ui:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/lawndon-pi-ui:${{ github.sha }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,8 +93,7 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/lawndon-pi-server:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/lawndon-pi-server:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/lawndon-pi-server:test
 
       - name: Test Docker build for UI
         uses: docker/build-push-action@v4
@@ -104,5 +103,4 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/lawndon-pi-ui:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/lawndon-pi-ui:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/lawndon-pi-ui:test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,7 @@ jobs:
           context: ./pi
           file: ./pi/Dockerfile.server
           push: false
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/lawndon-pi-server:test
 
@@ -101,6 +101,6 @@ jobs:
           context: ./pi
           file: ./pi/Dockerfile.ui
           push: false
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/lawndon-pi-ui:test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Tests](https://github.com/jordojordo/lawndon-lite/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/jordojordo/lawndon-lite/actions/workflows/tests.yml)
+[![Build Tests](https://github.com/jordojordo/lawndon/actions/workflows/tests.yaml/badge.svg?event=schedule)](https://github.com/jordojordo/lawndon/actions/workflows/tests.yaml)
 
 # Lawndon Lite
 

--- a/pi/Dockerfile.server
+++ b/pi/Dockerfile.server
@@ -4,12 +4,11 @@ WORKDIR /usr/src/app
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV NODE_ENV=production
 ENV CONFIG_PATH=/usr/src/app/config
 
 RUN corepack enable
 COPY server/package*.json ./
-RUN pnpm install
+RUN pnpm install --prod=false
 
 COPY server ./server
 WORKDIR /usr/src/app/server

--- a/pi/Dockerfile.ui
+++ b/pi/Dockerfile.ui
@@ -6,12 +6,11 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 RUN corepack enable
-COPY ui/package.json ui/pnpm-lock.yaml ./
+COPY ui/package.json ui/pnpm-lock.yaml ./ui/
+WORKDIR /usr/src/app/ui
 RUN pnpm install --prod=false
 
-COPY ui ./ui
-WORKDIR /usr/src/app/ui
-ENV PATH="/usr/src/app/node_modules/.bin:$PATH"
+COPY ui ./
 RUN pnpm build
 
 # Runtime stage

--- a/pi/Dockerfile.ui
+++ b/pi/Dockerfile.ui
@@ -4,14 +4,14 @@ WORKDIR /usr/src/app
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV VITE_NODE_ENV=production
 
 RUN corepack enable
-COPY ui/package*.json ./
-RUN pnpm install
+COPY ui/package.json ui/pnpm-lock.yaml ./
+RUN pnpm install --prod=false
 
 COPY ui ./ui
 WORKDIR /usr/src/app/ui
+ENV PATH="/usr/src/app/node_modules/.bin:$PATH"
 RUN pnpm build
 
 # Runtime stage

--- a/pi/server/package.json
+++ b/pi/server/package.json
@@ -20,12 +20,10 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "mathjs": "^14.0.0",
-    "socket.io": "^4.8.1",
-    "typescript": "^5.7.2"
+    "socket.io": "^4.8.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
-    "@types/dotenv": "^8.2.3",
     "@types/express": "^5.0.0",
     "@types/node": "^22.9.3",
     "eslint": "^9.15.0",
@@ -33,6 +31,7 @@
     "http-proxy-middleware": "^3.0.3",
     "nodemon": "^3.1.7",
     "ts-node": "^10.9.2",
-    "ts-node-dev": "^2.0.0"
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.7.2"
   }
 }

--- a/pi/server/package.json
+++ b/pi/server/package.json
@@ -20,7 +20,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "mathjs": "^14.0.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "typescript": "^5.7.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -32,7 +33,6 @@
     "http-proxy-middleware": "^3.0.3",
     "nodemon": "^3.1.7",
     "ts-node": "^10.9.2",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.7.2"
+    "ts-node-dev": "^2.0.0"
   }
 }

--- a/pi/server/pnpm-lock.yaml
+++ b/pi/server/pnpm-lock.yaml
@@ -23,16 +23,10 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.1
-      typescript:
-        specifier: ^5.7.2
-        version: 5.7.2
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.17
-      '@types/dotenv':
-        specifier: ^8.2.3
-        version: 8.2.3
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -57,6 +51,9 @@ importers:
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.9.3)(typescript@5.7.2)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
 
 packages:
 
@@ -158,10 +155,6 @@ packages:
 
   '@types/cors@2.8.17':
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
-
-  '@types/dotenv@8.2.3':
-    resolution: {integrity: sha512-g2FXjlDX/cYuc5CiQvyU/6kkbP1JtmGzh0obW50zD7OKeILVL0NSpPWLXVfqoAGQjom2/SLLx9zHq0KXvD6mbw==}
-    deprecated: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1166,10 +1159,6 @@ snapshots:
   '@types/cors@2.8.17':
     dependencies:
       '@types/node': 22.9.3
-
-  '@types/dotenv@8.2.3':
-    dependencies:
-      dotenv: 16.4.5
 
   '@types/estree@1.0.6': {}
 

--- a/pi/server/pnpm-lock.yaml
+++ b/pi/server/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -54,9 +57,6 @@ importers:
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.9.3)(typescript@5.7.2)
-      typescript:
-        specifier: ^5.7.2
-        version: 5.7.2
 
 packages:
 

--- a/pi/ui/package.json
+++ b/pi/ui/package.json
@@ -5,10 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_ENV=development vite",
-    "build": "run-p type-check \"build-only {@}\" --",
+    "build": "vue-tsc --build --force && vite build",
     "preview": "vite preview",
-    "build-only": "vite build",
-    "type-check": "vue-tsc --build --force",
     "lint": "eslint . --fix",
     "format": "prettier --write src/"
   },
@@ -16,10 +14,8 @@
     "d3": "^7.9.0",
     "pinia": "^2.2.6",
     "socket.io-client": "^4.8.1",
-    "typescript": "~5.6.3",
     "vue": "^3.5.13",
-    "vue-router": "^4.4.5",
-    "vue-tsc": "^2.1.10"
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
@@ -33,8 +29,10 @@
     "eslint-plugin-vue": "^9.31.0",
     "npm-run-all2": "^7.0.1",
     "prettier": "^3.3.3",
+    "typescript": "~5.6.3",
     "vite": "^5.4.11",
-    "vite-plugin-vue-devtools": "^7.6.4"
+    "vite-plugin-vue-devtools": "^7.6.4",
+    "vue-tsc": "^2.1.10"
   },
   "packageManager": "pnpm@9.14.2"
 }

--- a/pi/ui/package.json
+++ b/pi/ui/package.json
@@ -16,8 +16,10 @@
     "d3": "^7.9.0",
     "pinia": "^2.2.6",
     "socket.io-client": "^4.8.1",
+    "typescript": "~5.6.3",
     "vue": "^3.5.13",
-    "vue-router": "^4.4.5"
+    "vue-router": "^4.4.5",
+    "vue-tsc": "^2.1.10"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
@@ -31,10 +33,8 @@
     "eslint-plugin-vue": "^9.31.0",
     "npm-run-all2": "^7.0.1",
     "prettier": "^3.3.3",
-    "typescript": "~5.6.3",
     "vite": "^5.4.11",
-    "vite-plugin-vue-devtools": "^7.6.4",
-    "vue-tsc": "^2.1.10"
+    "vite-plugin-vue-devtools": "^7.6.4"
   },
   "packageManager": "pnpm@9.14.2"
 }

--- a/pi/ui/pnpm-lock.yaml
+++ b/pi/ui/pnpm-lock.yaml
@@ -17,12 +17,18 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
+      typescript:
+        specifier: ~5.6.3
+        version: 5.6.3
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.6.3)
       vue-router:
         specifier: ^4.4.5
         version: 4.4.5(vue@3.5.13(typescript@5.6.3))
+      vue-tsc:
+        specifier: ^2.1.10
+        version: 2.1.10(typescript@5.6.3)
     devDependencies:
       '@tsconfig/node22':
         specifier: ^22.0.0
@@ -57,18 +63,12 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
-      typescript:
-        specifier: ~5.6.3
-        version: 5.6.3
       vite:
         specifier: ^5.4.11
         version: 5.4.11(@types/node@22.9.3)
       vite-plugin-vue-devtools:
         specifier: ^7.6.4
         version: 7.6.4(rollup@4.27.4)(vite@5.4.11(@types/node@22.9.3))(vue@3.5.13(typescript@5.6.3))
-      vue-tsc:
-        specifier: ^2.1.10
-        version: 2.1.10(typescript@5.6.3)
 
 packages:
 

--- a/pi/ui/pnpm-lock.yaml
+++ b/pi/ui/pnpm-lock.yaml
@@ -17,18 +17,12 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
-      typescript:
-        specifier: ~5.6.3
-        version: 5.6.3
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.6.3)
       vue-router:
         specifier: ^4.4.5
         version: 4.4.5(vue@3.5.13(typescript@5.6.3))
-      vue-tsc:
-        specifier: ^2.1.10
-        version: 2.1.10(typescript@5.6.3)
     devDependencies:
       '@tsconfig/node22':
         specifier: ^22.0.0
@@ -63,12 +57,18 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
+      typescript:
+        specifier: ~5.6.3
+        version: 5.6.3
       vite:
         specifier: ^5.4.11
         version: 5.4.11(@types/node@22.9.3)
       vite-plugin-vue-devtools:
         specifier: ^7.6.4
         version: 7.6.4(rollup@4.27.4)(vite@5.4.11(@types/node@22.9.3))(vue@3.5.13(typescript@5.6.3))
+      vue-tsc:
+        specifier: ^2.1.10
+        version: 2.1.10(typescript@5.6.3)
 
 packages:
 


### PR DESCRIPTION
An issue with the dependencies for the server and ui with being `devDependencies` will cause them not to be installed when building for production. Moved them into normal dependencies.
Also switched the test workflow to use docker/build-push-action.